### PR TITLE
 Fix script saving to avoid extraneous file changes

### DIFF
--- a/Assets/Mirror/Migration/Editor/Scripts.cs
+++ b/Assets/Mirror/Migration/Editor/Scripts.cs
@@ -115,6 +115,9 @@ namespace Mirror.MigrationUtilities {
                         sr.Close();
                     }
 
+                    // store initial buffer to use in final comparison before writing out file
+                    var initialBuffer = scriptBuffer;
+
                     if (scriptBuffer.Contains("UnityWebRequest") && !scriptBuffer.Contains("using UnityWebRequest = UnityEngine.Networking.UnityWebRequest;")) {
                         int correctIndex = scriptBuffer.IndexOf("using UnityEngine.Networking;");
                         scriptBuffer = scriptBuffer.Insert(correctIndex, "using UnityWebRequest = UnityEngine.Networking.UnityWebRequest;" + System.Environment.NewLine);
@@ -176,10 +179,12 @@ namespace Mirror.MigrationUtilities {
                     if (backupFiles && !File.Exists(file + ".bak"))
                         File.Copy(file, file + ".bak");
 
-                    // Now the job is done, we want to write the data out to disk... 
-                    using (sw = new StreamWriter(file, false, Encoding.UTF8)) {
-                        sw.WriteLine(scriptBuffer);
-                        sw.Close();
+                    // Now the job is done, we want to write the data out to disk ONLY if the contents were actually changed... 
+                    if (initialBuffer != scriptBuffer) {
+                        using (sw = new StreamWriter(file, false, new UTF8Encoding(false))) {
+                            sw.Write(scriptBuffer.TrimStart());
+                            sw.Close();
+                        }
                     }
 
                     // Increment the modified counter for statistics.


### PR DESCRIPTION
1. Change WriteLine to Write to avoid adding an extra line ending on every file when saving
2. Only save a file if the script text was changed by the converter

This avoids git showing annoying whitespace changes on every single script file in your project, and fix 2 in particular massively speeds up the conversion process by avoiding writing files 90% of the time.